### PR TITLE
fix: disable sandbox during testing

### DIFF
--- a/lib/puppeteer.js
+++ b/lib/puppeteer.js
@@ -24,7 +24,7 @@ function run (outputDir, port, timeout, mode, runner, coverage) {
 async function _run (outputDir, port, timeout, mode, runner, coverage, callback) {
   let executionQueue = Promise.resolve()
 
-  const browser = await puppeteer.launch()
+  const browser = await puppeteer.launch({args: ['--no-sandbox']})
   const [page] = await browser.pages()
 
   // this works as a debounce exit method, when process.stdout.write() is used

--- a/lib/puppeteer.js
+++ b/lib/puppeteer.js
@@ -24,7 +24,7 @@ function run (outputDir, port, timeout, mode, runner, coverage) {
 async function _run (outputDir, port, timeout, mode, runner, coverage, callback) {
   let executionQueue = Promise.resolve()
 
-  const browser = await puppeteer.launch({args: ['--no-sandbox']})
+  const browser = await puppeteer.launch({ args: ['--no-sandbox'] })
   const [page] = await browser.pages()
 
   // this works as a debounce exit method, when process.stdout.write() is used


### PR DESCRIPTION
This option makes several features available in the browser and also enables running tests as root in linux environments (which is rather common when you’re running everything in a docker container anyway).