### PR TITLE
--webpack-config to merge in custom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Even though polendina is intended for "non-UI" testing, your tests run in a stan
  * `--stats`: Write webpack-stats.json with bundle; written to the `output-dir` so will be removed if `--cleanup` is specified (default: "false")
  * `--cleanup`: Remove the `output-dir` after execution (default: "false")
  * `--timeout`: Number of seconds to wait before auto-failing the test suite (default: "30")
+ * `--webpack-config`: Supply a path to a webpack.config.js to merge into Polendina's Webpack config (use with caution)
  * `--mocha-reporter`: Specify the Mocha reporter if the test runner is Mocha (default: "spec")
 
 ## Examples

--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -38,7 +38,12 @@ module.exports = function (env, options, runner) {
       ]
     },
     node: {
-      fs: 'empty'
+      dgram: 'empty',
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+      dns: 'empty',
+      child_process: 'empty'
     },
     module: {
       rules: [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "st": "^2.0.0",
     "strip-ansi": "^6.0.0",
     "webpack": "^4.41.5",
+    "webpack-merge": "^4.2.2",
     "yargs": "^15.1.0"
   },
   "bin": {
@@ -25,8 +26,9 @@
   },
   "scripts": {
     "lint": "standard",
-    "test:install": "for f in $(cd test/fixtures/; ls); do (cd test/fixtures/$f && grep devDependencies package.json > /dev/null && npm i --no-audit --no-fund); done",
-    "test": "npm run lint && npm run test:install && mocha test/test-*.js"
+    "test:install": "for f in $(cd test/fixtures/; ls); do (cd test/fixtures/$f && grep devDependencies package.json > /dev/null && npm i --no-audit --no-fund --no-package-lock) || true; done",
+    "test:run": "mocha test/test-*.js",
+    "test": "npm run lint && npm run test:install && npm run test:run"
   },
   "repository": {
     "type": "git",

--- a/polendina-cli.js
+++ b/polendina-cli.js
@@ -57,6 +57,11 @@ const argv = require('yargs')
     default: false,
     hidden: true
   })
+  .option('webpack-config', {
+    type: 'string',
+    describe: 'Supply a path to a webpack.config.js to merge into Polendina\'s Webpack config (use with caution)',
+    requiresArg: true
+  })
   .option('mocha-reporter', {
     type: 'string',
     describe: 'Specify the Mocha reporter',

--- a/polendina.js
+++ b/polendina.js
@@ -5,6 +5,7 @@ const http = require('http')
 const st = require('st')
 const rimraf = promisify(require('rimraf'))
 const webpack = promisify(require('webpack'))
+const merge = require('webpack-merge')
 const puppeteer = require('./lib/puppeteer')
 
 class Polendina {
@@ -31,7 +32,12 @@ class Polendina {
   }
 
   async build () {
-    const webpackConfig = require('./lib/webpack.config')(process.env, this._options, this._runnerModule)
+    let webpackConfig = require('./lib/webpack.config')(process.env, this._options, this._runnerModule)
+
+    if (this._options.webpackConfig) {
+      const userConfig = require(path.join(process.cwd(), this._options.webpackConfig))
+      webpackConfig = merge.smart(webpackConfig, userConfig)
+    }
 
     await fs.mkdir(this.outputDir, { recursive: true })
     const copyFiles = ['index.html', 'test-registry.js', 'page-run.js', 'common-run.js', this._runnerModule]

--- a/test/fixtures/webpack-merge/index.js
+++ b/test/fixtures/webpack-merge/index.js
@@ -1,0 +1,1 @@
+module.exports = 'bare test fixture'

--- a/test/fixtures/webpack-merge/package.json
+++ b/test/fixtures/webpack-merge/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fixture-webpack-merge",
+  "version": "1.0.0",
+  "description": "test fixture",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rvagg/polendina.git"
+  },
+  "license": "Apache-2.0"
+}

--- a/test/fixtures/webpack-merge/test.js
+++ b/test/fixtures/webpack-merge/test.js
@@ -1,0 +1,7 @@
+const assert = require('assert')
+const qs = require('querystring')
+
+assert.strictEqual(typeof assert.ok, 'function')
+console.log('assert.ok() is a function')
+assert.strictEqual(typeof qs.parse, 'function')
+console.log('querystring.parse() is a function')

--- a/test/fixtures/webpack-merge/webpack.config.js
+++ b/test/fixtures/webpack-merge/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  node: {
+    querystring: 'empty'
+  }
+}

--- a/test/test-webpack-merge.js
+++ b/test/test-webpack-merge.js
@@ -1,0 +1,36 @@
+/* globals describe it */
+
+const assert = require('assert')
+const path = require('path')
+const { runCli } = require('./common')
+
+const webpackMergeFixture = path.join(__dirname, 'fixtures/webpack-merge')
+
+describe('basic webpack-merge', function () {
+  this.timeout(20000)
+  it('should run plain', async () => {
+    const expected = `
+assert.ok() is a function
+querystring.parse() is a function
+  ✔ test.js
+`
+    const { stdout, code } = await runCli(webpackMergeFixture, '--runner=bare-sync')
+    assert.strictEqual(code, 0, 'exited with zero exit code')
+    assert.ok(stdout.includes(expected), 'stdout contains expected test output')
+    assert.ok(stdout.includes('Running bare-sync page tests with Puppeteer'), 'stdout contains expected output for running in page')
+  })
+
+  it('should fail with custom config', async () => {
+    const expectedStdout = `
+assert.ok() is a function
+  ✘ test.js
+`
+    const expectedStderr = '\'undefined\' === \'function\''
+
+    const { stdout, stderr, code } = await runCli(webpackMergeFixture, '--runner=bare-sync --webpack-config webpack.config.js')
+    assert.strictEqual(code, 1, 'exited with zero exit code')
+    assert.ok(stdout.includes(expectedStdout), 'stdout contains expected test output')
+    assert.ok(stderr.includes(expectedStderr), 'stderr contains expected test output')
+    assert.ok(stdout.includes('Running bare-sync page tests with Puppeteer'), 'stdout contains expected output for running in page')
+  })
+})


### PR DESCRIPTION
@carsonfarmer if you have time would you mind giving a quick review of this since it spawned from a comment you made?

Key change is in polendina.js, using [`webpackMerge.smart()`](https://github.com/survivejs/webpack-merge#mergesmartconfiguration-configuration).

I also updated the default webpack.config.js in this to exclude more of the core modules (this probably makes it a breaking change and warrants a major version bump, although I doubt it'd really break anyone). So `--webpack-config` probably wouldn't be something you'd need, but it does add a level of flexibility for those who want it.