### PR TITLE
mocha8 support, use npx instead of devDeps to not pollute dep chain

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -2,10 +2,10 @@ const path = require('path')
 const glob = require('glob')
 
 module.exports = function (env, options, runner) {
-  const bundleRun = path.resolve(options.outputDir, runner)
+  const bundleRun = path.normalize(path.resolve(options.outputDir, runner))
   const testFiles = options._.reduce((p, c) => {
     return p.concat(glob.sync(c, { absolute: true }))
-  }, [])
+  }, []).map(path.normalize)
 
   // our globs may be fruitless
   if (!testFiles.length) {
@@ -16,6 +16,7 @@ module.exports = function (env, options, runner) {
 
   return {
     mode: 'development',
+    context: process.cwd(),
     entry: testFiles,
     output: {
       path: path.resolve(process.cwd(), options.outputDir),

--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -27,14 +27,14 @@ module.exports = function (env, options, runner) {
     },
     resolve: {
       modules: [
-        path.join(__dirname, '../node_modules'),
-        path.join(process.cwd(), 'node_modules')
+        path.join(process.cwd(), 'node_modules'),
+        path.join(__dirname, '../node_modules')
       ]
     },
     resolveLoader: {
       modules: [
-        path.join(__dirname, '../node_modules'),
-        path.join(process.cwd(), 'node_modules')
+        path.join(process.cwd(), 'node_modules'),
+        path.join(__dirname, '../node_modules')
       ]
     },
     node: {

--- a/lib/wrap-loader.js
+++ b/lib/wrap-loader.js
@@ -19,10 +19,10 @@ loader.pitch = function pitch (remainingRequest) {
 
   // wrap the test in a function that is only called when we want it called
   return `
-    const registry = require(${JSON.stringify(`!!${path.resolve(argv.outputDir, 'test-registry.js')}`)})
-    registry.argv = JSON.parse('${JSON.stringify(argv)}')
+    const registry = require(${JSON.stringify(`!!${path.normalize(path.resolve(argv.outputDir, 'test-registry.js'))}`)})
+    registry.argv = JSON.parse(${JSON.stringify(JSON.stringify(argv))})
     registry.tests.push({
-      name: JSON.parse('${JSON.stringify(path.relative(process.cwd(), remainingRequest))}'),
+      name: JSON.parse('${JSON.stringify(path.normalize(path.relative(process.cwd(), remainingRequest)))}'),
       load: () => { return require(${JSON.stringify(`!!${remainingRequest}`)}) }
     })
   `

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "glob": "^7.1.6",
     "puppeteer": "^5.2.1",
     "raw-loader": "^4.0.0",
+    "readable-stream": "^2.3.7",
     "rimraf": "^3.0.0",
     "st": "^2.0.0",
     "strip-ansi": "^6.0.0",
@@ -19,15 +20,10 @@
     "polendina": "./polendina-cli.js",
     "polendina-node": "./polendina-node-cli.js"
   },
-  "devDependencies": {
-    "mocha": "^7.0.0",
-    "standard": "^14.3.1",
-    "tape": "^4.12.1"
-  },
   "scripts": {
-    "lint": "standard",
+    "lint": "npx standard",
     "test:install": "for f in $(cd test/fixtures/; ls); do (cd test/fixtures/$f && grep devDependencies package.json > /dev/null && npm i --no-audit --no-fund --no-package-lock) || true; done",
-    "test:run": "mocha test/test-*.js",
+    "test:run": "npx mocha test/test-*.js",
     "test": "npm run lint && npm run test:install && npm run test:run"
   },
   "repository": {

--- a/polendina.js
+++ b/polendina.js
@@ -89,7 +89,12 @@ class Polendina {
   }
 
   _executeMode (mode) {
-    const mount = st({ path: this.outputDir, index: 'index.html', url: '/' })
+    const mount = st({
+      path: this.outputDir,
+      index: 'index.html',
+      url: '/',
+      cache: false
+    })
     return new Promise((resolve, reject) => {
       const server = http.createServer((req, res) => {
         mount(req, res, () => {

--- a/resources/mocha-run.js
+++ b/resources/mocha-run.js
@@ -1,28 +1,29 @@
-/* globals mocha Mocha */
-
 // in-browser setup and runner for Mocha, at end of bundle
 
-require('mocha/mocha.js')
+const mochaExport = require('mocha/mocha.js')
 const { registry, executionQueue, log, setup } = require('./common-run')
 
 function runMocha () {
-  mocha.setup({ reporter: registry.argv.mochaReporter, ui: 'bdd' })
+  // mocha@8 exports what we want, mocha@7 sets a global
+  const mochaLocal = global.mocha ? global.mocha : mochaExport
+  global._mocha = mochaLocal
+  mochaLocal.setup({ reporter: registry.argv.mochaReporter, ui: 'bdd' })
   // mocha@7 deprecated useColors()
-  if (typeof mocha.color === 'function') {
-    mocha.color(true)
-  } else if (typeof mocha.useColors === 'function') {
-    mocha.useColors(true)
+  if (typeof mochaLocal.color === 'function') {
+    mochaLocal.color(true)
+  } else if (typeof mochaLocal.useColors === 'function') {
+    mochaLocal.useColors(true)
   }
 
   // the well-behaved reporters, like spec, are easy to intercept
-  Mocha.reporters.Base.consoleLog = log.info
+  mochaLocal.constructor.reporters.Base.consoleLog = log.info
 
   for (const mod of registry.tests) {
     mod.load()
   }
 
   let errors = 0
-  mocha
+  mochaLocal
     .run((_errors) => { errors = _errors })
     .on('end', (...args) => {
       executionQueue(() => global.polendinaEnd(errors))

--- a/test/fixtures/mocha8/index.js
+++ b/test/fixtures/mocha8/index.js
@@ -1,0 +1,1 @@
+module.exports = 'polendina test'

--- a/test/fixtures/mocha8/package.json
+++ b/test/fixtures/mocha8/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "fixture-tape",
+  "name": "fixture-mocha8",
   "version": "1.0.0",
-  "description": "test fixture",
+  "description": "test-fixture",
   "main": "index.js",
   "scripts": {
-    "test": "tape test.js"
+    "test": "mocha test-*.js"
   },
   "author": "Rod <rod@vagg.org> (http://r.va.gg/)",
   "license": "Apache-2.0",
@@ -13,6 +13,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "^5.0.1"
+    "mocha": "^8.0.0"
   }
 }

--- a/test/fixtures/mocha8/test-1.js
+++ b/test/fixtures/mocha8/test-1.js
@@ -1,0 +1,14 @@
+/* globals describe it */
+
+const fixture = require('./')
+const assert = require('assert')
+
+describe('test suite 1', () => {
+  it('test case 1', () => {
+    assert.strictEqual(fixture, 'polendina test')
+  })
+
+  it('test case 2', () => {
+    assert.ok(true, 'all good')
+  })
+})

--- a/test/fixtures/mocha8/test-2.js
+++ b/test/fixtures/mocha8/test-2.js
@@ -1,0 +1,19 @@
+/* globals describe it WorkerGlobalScope ServiceWorkerGlobalScope */
+
+const assert = require('assert')
+
+describe('test suite 2 - worker', () => {
+  if (typeof ServiceWorkerGlobalScope !== 'undefined' && global instanceof ServiceWorkerGlobalScope) {
+    it('is in serviceworker', () => {
+      assert.strictEqual(typeof ServiceWorkerGlobalScope, 'function')
+    })
+  } else if (typeof WorkerGlobalScope !== 'undefined' && global instanceof WorkerGlobalScope) {
+    it('is in worker', () => {
+      assert.strictEqual(typeof WorkerGlobalScope, 'function')
+    })
+  } else {
+    it('is not in worker', () => {
+      assert.strictEqual(typeof WorkerGlobalScope, 'undefined')
+    })
+  }
+})

--- a/test/fixtures/mocha8/test-3.js
+++ b/test/fixtures/mocha8/test-3.js
@@ -1,0 +1,14 @@
+/* globals describe it */
+
+const fixture = require('./')
+const assert = require('assert')
+
+describe('test suite 3', () => {
+  it('test case 1', () => {
+    assert.strictEqual(fixture, 'polendina test')
+  })
+
+  it('test case 2', () => {
+    assert.ok(true, 'all good')
+  })
+})

--- a/test/fixtures/tape-failure/package.json
+++ b/test/fixtures/tape-failure/package.json
@@ -13,6 +13,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "^4.12.1"
+    "tape": "^5.0.1"
   }
 }

--- a/test/test-tape.js
+++ b/test/test-tape.js
@@ -13,15 +13,15 @@ describe('basic tape', function () {
 TAP version 13
 # test suite 1
 # test case 1
-ok 1 should be equal
+ok 1 should be strictly equal
 # test case 2
 ok 2 all good
 # test suite 2 - worker
 # is WORKER
-ok 3 should be equal
+ok 3 should be strictly equal
 # test suite 3
 # test case 1
-ok 4 should be equal
+ok 4 should be strictly equal
 # test case 2
 ok 5 all good
 
@@ -80,7 +80,7 @@ describe('failing tape', function () {
 TAP version 13
 # test suite 1 - worker
 # is WORKER
-ok 1 should be equal
+ok 1 should be strictly equal
 # test suite 2 - failure
 # test case 1
 not ok 2 bork


### PR DESCRIPTION
Fixes: https://github.com/rvagg/polendina/issues/13

Dual support for mocha8 and mocha7, detects at runtime how it has to deal with the beast.

Removed devDependencies from here and am using npx now to run everything, the devDeps in node_modules messes up the state that end-users will have.

Switched resolution order to put local node_modules before polendina's. But also included readable-stream@2 here as a direct dep because tape (and others) that use an older core `'streams`' pattern get messed up. Ideally a package will depend on readable-stream, but many don't and Webpack's ancient `'streams'` polyfill is a mess.