### PR TITLE
fix!: update deps (incl mocha@10) & silence mocha warning

### DIFF
--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -42,6 +42,7 @@ export function webpackConfig (env, options, runner) {
       ]
     },
     module: {
+      exprContextCritical: false, // mocha stil has a require.resolve resulting in a noisy warning
       rules: [
         {
           test: testFiles,

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
     "glob": "^8.0.1",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "puppeteer": "~13.7.0",
-    "raw-loader": "~4.0.2",
+    "puppeteer": "^13.7.0",
+    "raw-loader": "^4.0.2",
     "readable-stream": "^3.6.0",
     "rimraf": "^3.0.2",
     "st": "^3.0.0",
     "stream-browserify": "^3.0.0",
     "strip-ansi": "^7.0.1",
-    "webpack": "~5.72.0",
-    "webpack-merge": "~5.8.0",
-    "yargs": "^17.3.0"
+    "webpack": "^5.72.0",
+    "webpack-merge": "^5.8.0",
+    "yargs": "^17.4.1"
   },
   "bin": {
     "polendina": "./polendina-cli.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "glob": "^8.0.1",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "puppeteer": "~13.5.0",
+    "puppeteer": "~13.7.0",
     "raw-loader": "~4.0.2",
     "readable-stream": "^3.6.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "dependencies": {
     "ansi-colors": "^4.1.1",
-    "glob": "^7.2.0",
+    "glob": "^8.0.1",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "puppeteer": "~13.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "st": "^3.0.0",
     "stream-browserify": "^3.0.0",
     "strip-ansi": "^7.0.1",
-    "webpack": "~5.70.0",
+    "webpack": "~5.72.0",
     "webpack-merge": "~5.8.0",
     "yargs": "^17.3.0"
   },

--- a/resources/mocha-run.js
+++ b/resources/mocha-run.js
@@ -1,6 +1,6 @@
 // in-browser setup and runner for Mocha, at end of bundle
 
-import mochaExport from 'mocha/mocha-es2018.js'
+import mochaExport from 'mocha/mocha.js'
 import { registry, executionQueue, log, setup } from './common-run.js'
 
 function runMocha () {

--- a/test/fixtures/bare-async-esm/package.json
+++ b/test/fixtures/bare-async-esm/package.json
@@ -14,6 +14,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-async-failure-esm/package.json
+++ b/test/fixtures/bare-async-failure-esm/package.json
@@ -14,6 +14,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-async-failure/package.json
+++ b/test/fixtures/bare-async-failure/package.json
@@ -13,6 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-async/package.json
+++ b/test/fixtures/bare-async/package.json
@@ -13,6 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-sync-esm/package.json
+++ b/test/fixtures/bare-sync-esm/package.json
@@ -14,6 +14,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-sync-failure-esm/package.json
+++ b/test/fixtures/bare-sync-failure-esm/package.json
@@ -14,6 +14,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-sync-failure/package.json
+++ b/test/fixtures/bare-sync-failure/package.json
@@ -13,6 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/bare-sync/package.json
+++ b/test/fixtures/bare-sync/package.json
@@ -13,6 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }

--- a/test/fixtures/mocha-esm/package.json
+++ b/test/fixtures/mocha-esm/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "~9.2.0"
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
   }
 }

--- a/test/fixtures/mocha-failure-esm/package.json
+++ b/test/fixtures/mocha-failure-esm/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "~9.2.0"
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
   }
 }

--- a/test/fixtures/mocha-failure/package.json
+++ b/test/fixtures/mocha-failure/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "~9.2.0"
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
   }
 }

--- a/test/fixtures/mocha/package.json
+++ b/test/fixtures/mocha/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "chai": "^4.3.4",
-    "mocha": "~9.2.0"
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
   }
 }

--- a/test/fixtures/tape-esm/package.json
+++ b/test/fixtures/tape-esm/package.json
@@ -14,6 +14,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "~5.5.0"
+    "tape": "^5.5.3"
   }
 }

--- a/test/fixtures/tape-failure-esm/package.json
+++ b/test/fixtures/tape-failure-esm/package.json
@@ -14,6 +14,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "~5.5.0"
+    "tape": "^5.5.3"
   }
 }

--- a/test/fixtures/tape-failure/package.json
+++ b/test/fixtures/tape-failure/package.json
@@ -13,6 +13,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "~5.5.0"
+    "tape": "^5.5.3"
   }
 }

--- a/test/fixtures/tape/package.json
+++ b/test/fixtures/tape/package.json
@@ -13,6 +13,6 @@
     "url": "https://github.com/rvagg/polendina.git"
   },
   "devDependencies": {
-    "tape": "~5.5.0"
+    "tape": "^5.5.3"
   }
 }

--- a/test/fixtures/webpack-merge/package.json
+++ b/test/fixtures/webpack-merge/package.json
@@ -13,6 +13,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "chai": "^4.3.4"
+    "chai": "^4.3.6"
   }
 }


### PR DESCRIPTION
This is a potential BREAKING CHANGE because it bumps the required version of
mocha to v10. The import that we have to use has changed from
mocha/mocha-2018.js to mocha/mocha.js, so it won't be happy with a library
that uses anything less than mocha@10.
